### PR TITLE
Fixes for build/warnings and also a performance improvement

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -6,10 +6,10 @@ clean:
 	-rm %DESTDIR%/resources/libraries/%sha1% %DESTDIR%/*.o
 
 %DESTDIR%/resources/libraries/%sha1%: sha1%O%
-	    %LD% %LDSHARED% %LDFLAGS% %LIBS% %LDOUT%%DESTDIR%/resources/libraries/%sha1% $^
+	%LD% %LDSHARED% %LDFLAGS% %LIBS% %LDOUT%%DESTDIR%/resources/libraries/%sha1% sha1%O%
 
 sha1%O%: src/sha1.c
-	    %CC% -c %CCSHARED% %CCFLAGS% %CCOUT% $@ $<
+	%CC% -c %CCSHARED% %CCFLAGS% %CCOUT% sha1%O% src/sha1.c
 
 test: all
-	prove -e 'perl6 -Ilib' t
+	prove -e "perl6 -Ilib" t

--- a/lib/Digest/SHA1/Native.pm6
+++ b/lib/Digest/SHA1/Native.pm6
@@ -4,23 +4,19 @@ use NativeCall;
 
 constant SHA1 = %?RESOURCES<libraries/sha1>.abspath;
 
-sub compute_sha1(CArray[uint8], size_t, CArray[uint8]) is native( SHA1 ) { * }
+sub compute_sha1(Blob, size_t, CArray[uint8]) is native( SHA1 ) { * }
 
 multi sub sha1-hex(Str $in) is export {
     sha1-hex($in.encode);
 }
 
-multi sub sha1-hex($in) is export {
-    my $text = CArray[uint8].new;
-
-    $text[$_] = $in[$_] for 0..$in.elems-1;
-
+multi sub sha1-hex(Blob $in) is export {
     my size_t $len = $in.elems;
 
     my CArray[uint8] $hash .= new;
     $hash[79] = 0;
 
-    compute_sha1($text,$len,$hash);
+    compute_sha1($in,$len,$hash);
 
     my $str = $hash.list».chr.join.lc;
 

--- a/src/sha1.c
+++ b/src/sha1.c
@@ -83,18 +83,10 @@ Still 100% public domain
 added compute_sha1
 */
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT extern
-#endif
-
 #include <stdio.h>
 #include <string.h>
 
 #include "sha1.h"
-
-void SHA1_Transform(unsigned int state[5], const unsigned char buffer[64]);
 
 #define rol(value, bits) (((value) << (bits)) | ((value) >> (32 - (bits))))
 
@@ -118,7 +110,7 @@ void SHA1_Transform(unsigned int state[5], const unsigned char buffer[64]);
 #define R4(v,w,x,y,z,i) z+=(w^x^y)+blk(i)+0xCA62C1D6+rol(v,5);w=rol(w,30);
 
 /* Hash a single 512-bit block. This is the core of the algorithm. */
-void SHA1_Transform(unsigned int state[5], const unsigned char buffer[64])
+static void SHA1_Transform(unsigned int state[5], const unsigned char buffer[64])
 {
     unsigned int a, b, c, d, e;
     typedef union {
@@ -171,7 +163,7 @@ void SHA1_Transform(unsigned int state[5], const unsigned char buffer[64])
 
 
 /* SHA1Init - Initialize new context */
-void SHA1_Init(SHA1_CTX* context)
+static void SHA1_Init(SHA1_CTX* context)
 {
     /* SHA1 initialization constants */
     context->state[0] = 0x67452301;
@@ -184,7 +176,7 @@ void SHA1_Init(SHA1_CTX* context)
 
 
 /* Run your data through this. */
-void SHA1_Update(SHA1_CTX* context, const unsigned char* data, const size_t len)
+static void SHA1_Update(SHA1_CTX* context, const unsigned char* data, const size_t len)
 {
     size_t i, j;
 
@@ -205,7 +197,7 @@ void SHA1_Update(SHA1_CTX* context, const unsigned char* data, const size_t len)
 
 
 /* Add padding and return the message digest. */
-void SHA1_Final(SHA1_CTX* context, unsigned char digest[SHA1_DIGEST_SIZE])
+static void SHA1_Final(SHA1_CTX* context, unsigned char digest[SHA1_DIGEST_SIZE])
 {
     unsigned int   i;
     unsigned char  finalcount[8];
@@ -234,7 +226,7 @@ void SHA1_Final(SHA1_CTX* context, unsigned char digest[SHA1_DIGEST_SIZE])
 
 
 /* Produces a hex output of the digest. */
-void SHA1_DigestToHex(const unsigned char digest[SHA1_DIGEST_SIZE], char *output)
+static void SHA1_DigestToHex(const unsigned char digest[SHA1_DIGEST_SIZE], char *output)
 {
     int i,j;
     char *c = output;
@@ -247,10 +239,12 @@ void SHA1_DigestToHex(const unsigned char digest[SHA1_DIGEST_SIZE], char *output
     }
 }
 
-DLLEXPORT void compute_sha1(const unsigned char *str, size_t len, unsigned char *output) {
+void compute_sha1(const unsigned char *str, size_t len, unsigned char *output) {
+    unsigned char digest[SHA1_DIGEST_SIZE];
     SHA1_CTX context;
-    SHA1Init(&context);
-    SHA1Update(&context, str, len);
-    SHA1Final(&context, output);
+    SHA1_Init(&context);
+    SHA1_Update(&context, str, len);
+    SHA1_Final(&context, digest);
+    SHA1_DigestToHex(digest, output);
 }
 

--- a/src/sha1.c
+++ b/src/sha1.c
@@ -83,6 +83,12 @@ Still 100% public domain
 added compute_sha1
 */
 
+#ifdef _WIN32
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT extern
+#endif
+
 #include <stdio.h>
 #include <string.h>
 
@@ -241,7 +247,7 @@ void SHA1_DigestToHex(const unsigned char digest[SHA1_DIGEST_SIZE], char *output
     }
 }
 
-void compute_sha1(const unsigned char *str, size_t len, unsigned char *output) {
+DLLEXPORT void compute_sha1(const unsigned char *str, size_t len, unsigned char *output) {
     SHA1_CTX context;
     SHA1Init(&context);
     SHA1Update(&context, str, len);

--- a/src/sha1.h
+++ b/src/sha1.h
@@ -4,6 +4,12 @@
 #ifndef __SHA1_H
 #define __SHA1_H
 
+#ifdef _WIN32
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT extern
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -16,10 +22,7 @@ typedef struct {
 
 #define SHA1_DIGEST_SIZE 20
 
-void SHA1_Init(SHA1_CTX* context);
-void SHA1_Update(SHA1_CTX* context, const unsigned char* data, const size_t len);
-void SHA1_Final(SHA1_CTX* context, unsigned char digest[SHA1_DIGEST_SIZE]);
-void SHA1_DigestToHex(const unsigned char digest[SHA1_DIGEST_SIZE], char *output);
+DLLEXPORT void compute_sha1(const unsigned char *str, size_t len, unsigned char *output);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
See the messages on each commit, but in summary this bunch:

* Fix installation of this library on Windows
* Get rid of build warnings on Linux
* Make things a load faster if you're using it for large amounts of data by avoiding a copy loop into a CArray

Passes all tests on Linux and Windows.