### PR TITLE
Fix compiled file containing absolute path of the build directory

### DIFF
--- a/lib/Digest/SHA1/Native.pm6
+++ b/lib/Digest/SHA1/Native.pm6
@@ -2,7 +2,7 @@ unit module Digest::SHA1::Native;
 
 use NativeCall;
 
-constant SHA1 = %?RESOURCES<libraries/sha1>.absolute;
+constant SHA1 = %?RESOURCES<libraries/sha1>;
 
 sub compute_sha1(Blob, size_t, CArray[uint8]) is native( SHA1 ) { * }
 


### PR DESCRIPTION
Modules packages for Linux distributions are often built in separate build directories
and will be moved to their final location only on installation. Thus a path may be correct
at compile time but different in the actual runtime. %?RESOURCES takes this into
account by returning Distribution::Resource objects which do the right thing. NativeCall
can work with those, so no need to absolutify paths.