### PR TITLE
Do not mutate input buffer when computing the SHA1

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -14,7 +14,7 @@
     ],
     "description" : "p6 bindings to C implementation of SHA1",
     "test-depends" : [ ],
-    "version" : "0.03",
+    "version" : "0.04",
     "license" : "Artistic-2.0",
     "authors" : [
         "Brian Duggan"

--- a/src/sha1.c
+++ b/src/sha1.c
@@ -117,9 +117,9 @@ static void SHA1_Transform(unsigned int state[5], const unsigned char buffer[64]
         unsigned char c[64];
         unsigned int  l[16];
     } CHAR64LONG16;
-    CHAR64LONG16* block;
-
-    block = (CHAR64LONG16*)buffer;
+    CHAR64LONG16 block_copy;
+    CHAR64LONG16 *block = &block_copy;
+    memcpy(&block_copy, buffer, sizeof(CHAR64LONG16));
 
     /* Copy context->state[] to working vars */
     a = state[0];

--- a/t/04-big.t
+++ b/t/04-big.t
@@ -3,4 +3,9 @@ use Test;
 
 is sha1-hex( ('z' x 10000) ),  '8ae70c86655f6edc2c32923a7d0b73aea813ed6d', 'long string';
 
+my $blob = ('z' x 10000).encode('ascii');
+my $orig = $blob.clone;
+is sha1-hex($blob), '8ae70c86655f6edc2c32923a7d0b73aea813ed6d', 'long buffer';
+is-deeply $blob, $orig, 'Calculating SHA-1 does not mangle the input buffer';
+
 done-testing;


### PR DESCRIPTION
In some cases, the input that was to be SHA1'd would be modified, which
was something of a problem if you were, for example, hashing a buffer
and then writing it to a file: the content to be written to the file
was no longer what it originally was! This only seemed to happen if the
buffer was long enough; the case in the added test triggered the
now-fixed bug.