### PR TITLE
Fix build on Rakudo installed from distro package

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -6,7 +6,7 @@ clean:
 	-rm %DESTDIR%/resources/libraries/%sha1% %DESTDIR%/*.o
 
 %DESTDIR%/resources/libraries/%sha1%: sha1%O%
-	%LD% %LDSHARED% %LDFLAGS% %LIBS% %LDOUT%%DESTDIR%/resources/libraries/%sha1% sha1%O%
+	%LD% %LDSHARED% %LDFLAGS% %LDOUT%%DESTDIR%/resources/libraries/%sha1% sha1%O%
 
 sha1%O%: src/sha1.c
 	%CC% -c %CCSHARED% %CCFLAGS% %CCOUT% sha1%O% src/sha1.c


### PR DESCRIPTION
`%LIBS%` contains native libraries that MoarVM itself is linked against, e.g. libuv,
libtommath and the optional libffi. If bundled libraries are used, they may not get
installed system wide, so will not be found. `-lffi` would require a `-devel` package
to get the `libffi.so` symlink. The actual library may be called libffi8.so.

The Digest::SHA1::Native helper library actually doesn't need any of those libraries
as it does not link against MoarVM. So there is no need to add `%LIBS%` to the
linker call.